### PR TITLE
Add kubernetes_metadata_filter

### DIFF
--- a/fluentd-loki/Dockerfile
+++ b/fluentd-loki/Dockerfile
@@ -2,7 +2,10 @@ FROM fluent/fluentd:v1.14-debian
 
 USER root
 
+RUN apt-get update && apt-get install build-essential g++ --yes && apt-get autoremove --yes
+
 RUN fluent-gem install fluent-plugin-grafana-loki \ 
-    && fluent-gem install fluent-plugin-parser-cri --no-document
+    && fluent-gem install fluent-plugin-parser-cri --no-document \
+    && fluent-gem install fluent-plugin-kubernetes_metadata_filter
 
 USER fluent


### PR DESCRIPTION
## Why

<!--- Restate the problem addressed by the PR here --->

We want to get the metadata from kubernetes like podnames

## How does this PR address it?

<!--- Restate the basic ideas behind your solution --->
<!--- Here it is also a good space to put details of your implementation --->

Adds [a plugin](https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter) that can get this metadata for us